### PR TITLE
Gradle build improvements

### DIFF
--- a/.github/workflows/0-on-demand.yaml
+++ b/.github/workflows/0-on-demand.yaml
@@ -64,6 +64,9 @@ env:
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+      strategy:
+        fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/1-unit.yaml
+++ b/.github/workflows/1-unit.yaml
@@ -49,11 +49,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/2-system.yaml
+++ b/.github/workflows/2-system.yaml
@@ -44,11 +44,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/3-multi-runtime.yaml
+++ b/.github/workflows/3-multi-runtime.yaml
@@ -44,11 +44,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/4-standalone.yaml
+++ b/.github/workflows/4-standalone.yaml
@@ -44,11 +44,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/5-scheduler.yaml
+++ b/.github/workflows/5-scheduler.yaml
@@ -44,11 +44,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/6-performance.yaml
+++ b/.github/workflows/6-performance.yaml
@@ -44,11 +44,14 @@ env:
 
   # github
   GH_BUILD: ${{ github.event_name }}-${{ github.sha }}
-  GH_BRANCH: ${{ github.head_ref || github.ref_name }} 
+  GH_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   openwhisk:
     runs-on: ubuntu-22.04
+    continue-on-error: false
+    strategy:
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -79,9 +82,9 @@ jobs:
       - run: OPENWHISK_HOST="172.17.0.1" USERS="1" REQUESTS_PER_SEC="1" ./gradlew gatlingRun-org.apache.openwhisk.ColdBlockingInvokeSimulation
         continue-on-error: true
       - name: Slack Notification
-        run: > 
-             ./tools/github/writeOnSlack.sh
-             "[$TEST_SUITE]" ${{ steps.tests.outcome }} on ${GH_BUILD}
-             $'\nbranch:' $GH_BRANCH
-             $'\nmessage:' "$(git log -1 --oneline | cat)"
-             $'\nCheck GitHub logs for results'
+        run: >
+          ./tools/github/writeOnSlack.sh
+          "[$TEST_SUITE]" ${{ steps.tests.outcome }} on ${GH_BUILD}
+          $'\nbranch:' $GH_BRANCH
+          $'\nmessage:' "$(git log -1 --oneline | cat)"
+          $'\nCheck GitHub logs for results'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
@@ -101,7 +101,7 @@ subprojects {
         if (project.plugins.hasPlugin('application')) {
             //Ensure that dist archive name does not contain version
             distTar {
-                archiveName = "${project.name}.tar"
+                archiveFileName = "${project.name}.tar"
             }
 
             //Avoid generating the zip files from maven installations

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     api "commons-codec:commons-codec:1.9"
     api "commons-io:commons-io:2.11.0"
     api "commons-collections:commons-collections:3.2.2"
-    api "org.apache.kafka:kafka-clients:2.4.0"
+    api "org.apache.kafka:kafka-clients:2.8.2"
     api "org.apache.httpcomponents:httpclient:4.5.5"
     api "com.fasterxml.uuid:java-uuid-generator:3.1.3"
     api "com.github.ben-manes.caffeine:caffeine:2.6.2"

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/AverageRingBuffer.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/AverageRingBuffer.scala
@@ -32,18 +32,12 @@ object AverageRingBuffer {
 class AverageRingBuffer(private val maxSize: Int) {
   private var elements = Vector.empty[Double]
   private var sum = 0.0
-  private var max = 0.0
-  private var min = 0.0
 
   def nonEmpty: Boolean = elements.nonEmpty
 
   def average: Double = {
     val size = elements.size
-    if (size > 2) {
-      (sum - max - min) / (size - 2)
-    } else {
-      sum / size
-    }
+    sum / size
   }
 
   def add(el: Double): Unit = synchronized {
@@ -53,12 +47,6 @@ class AverageRingBuffer(private val maxSize: Int) {
     } else {
       sum += el
       elements = elements :+ el
-    }
-    if (el > max) {
-      max = el
-    }
-    if (el < min) {
-      min = el
     }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
@@ -55,6 +55,7 @@ class KafkaConsumerConnector(
 
   // Currently consumed offset, is used to calculate the topic lag.
   // It is updated from one thread in "peek", no concurrent data structure is necessary
+  // Note: Currently, this value used for metric reporting will not be accurate if using a multi-partition topic.
   private var offset: Long = 0
 
   // Markers for metrics, initialized only once

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -64,7 +64,7 @@ object KafkaMessagingProvider extends MessagingProvider {
 
     Try(AdminClient.create(commonConfig + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> config.kafkaHosts)))
       .flatMap(client => {
-        val partitions = 1
+        val partitions = topicConfig.getOrElse("partitions", "1").toInt
         val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
 
         def createTopic(retries: Int = 5): Try[Unit] = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
@@ -51,7 +51,7 @@ class KafkaProducerConnector(
   /** Sends msg to topic. This is an asynchronous operation. */
   override def send(topic: String, msg: Message, retry: Int = 3): Future[ResultMetadata] = {
     implicit val transid: TransactionId = msg.transid
-    val record = new ProducerRecord[String, String](topic, "messages", msg.serialize)
+    val record = new ProducerRecord[String, String](topic, msg.serialize)
     val produced = Promise[ResultMetadata]()
 
     Future {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
@@ -43,13 +43,14 @@ case class UserLimits(invocationsPerMinute: Option[Int] = None,
                       maxActionLogs: Option[LogLimit] = None,
                       minActionTimeout: Option[TimeLimit] = None,
                       maxActionTimeout: Option[TimeLimit] = None,
-                      minActionConcurrency: Option[ConcurrencyLimit] = None,
-                      maxActionConcurrency: Option[ConcurrencyLimit] = None,
+                      minActionConcurrency: Option[IntraConcurrencyLimit] = None,
+                      maxActionConcurrency: Option[IntraConcurrencyLimit] = None,
                       maxParameterSize: Option[ByteSize] = None,
                       maxPayloadSize: Option[ByteSize] = None,
                       truncationSize: Option[ByteSize] = None,
                       warmedContainerKeepingCount: Option[Int] = None,
-                      warmedContainerKeepingTimeout: Option[String] = None) {
+                      warmedContainerKeepingTimeout: Option[String] = None,
+                      maxActionInstances: Option[Int] = None) {
 
   def allowedMaxParameterSize: ByteSize = {
     val namespaceLimit = maxParameterSize getOrElse (Parameters.MAX_SIZE_DEFAULT)
@@ -73,16 +74,16 @@ case class UserLimits(invocationsPerMinute: Option[Int] = None,
   }
 
   def allowedMaxActionConcurrency: Int = {
-    val namespaceLimit = maxActionConcurrency.map(_.maxConcurrent) getOrElse (ConcurrencyLimit.MAX_CONCURRENT_DEFAULT)
-    if (namespaceLimit > ConcurrencyLimit.MAX_CONCURRENT) {
-      ConcurrencyLimit.MAX_CONCURRENT
+    val namespaceLimit = maxActionConcurrency.map(_.maxConcurrent) getOrElse (IntraConcurrencyLimit.MAX_CONCURRENT_DEFAULT)
+    if (namespaceLimit > IntraConcurrencyLimit.MAX_CONCURRENT) {
+      IntraConcurrencyLimit.MAX_CONCURRENT
     } else namespaceLimit
   }
 
   def allowedMinActionConcurrency: Int = {
-    val namespaceLimit = minActionConcurrency.map(_.maxConcurrent) getOrElse (ConcurrencyLimit.MIN_CONCURRENT_DEFAULT)
-    if (namespaceLimit < ConcurrencyLimit.MIN_CONCURRENT) {
-      ConcurrencyLimit.MIN_CONCURRENT
+    val namespaceLimit = minActionConcurrency.map(_.maxConcurrent) getOrElse (IntraConcurrencyLimit.MIN_CONCURRENT_DEFAULT)
+    if (namespaceLimit < IntraConcurrencyLimit.MIN_CONCURRENT) {
+      IntraConcurrencyLimit.MIN_CONCURRENT
     } else namespaceLimit
   }
 
@@ -127,13 +128,12 @@ case class UserLimits(invocationsPerMinute: Option[Int] = None,
       TimeLimit.MIN_DURATION
     } else namespaceLimit
   }
-
 }
 
 object UserLimits extends DefaultJsonProtocol {
   val standardUserLimits = UserLimits()
   private implicit val byteSizeSerdes = size.serdes
-  implicit val serdes = jsonFormat18(UserLimits.apply)
+  implicit val serdes = jsonFormat19(UserLimits.apply)
 }
 
 protected[core] case class Namespace(name: EntityName, uuid: UUID)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceConcurrencyLimit.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.entity
+
+import org.apache.openwhisk.http.Messages
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import spray.json._
+
+/**
+ * InstanceConcurrencyLimit encapsulates max allowed container concurrency for an action within a given namespace.
+ * A user is given a max concurrency for their entire namespace, but this doesn't allow for any fairness across their actions
+ * during load spikes. This action limit allows a user to specify max container concurrency for a specific action within the
+ * constraints of their namespace limit. By default, this limit does not exist and therefore the namespace concurrency limit is used.
+ * The allowed range is thus [1, namespaceConcurrencyLimit]. If this config is not used by any actions, then the default behavior
+ * of openwhisk continues in which any action can use the entire concurrency limit of the namespace. The limit less than namespace
+ * limit check occurs at the api level.
+ *
+ * NOTE: This limit is only leveraged on openwhisk v2 with the scheduler service. If this limit is set on a deployment of openwhisk
+ * not using the scheduler service, the limit will do nothing.
+ *
+ *
+ * @param maxConcurrentInstances the max number of concurrent activations in a single container
+ */
+protected[entity] class InstanceConcurrencyLimit private(val maxConcurrentInstances: Int) extends AnyVal
+
+protected[core] object InstanceConcurrencyLimit extends ArgNormalizer[InstanceConcurrencyLimit] {
+
+  /** These values are set once at the beginning. Dynamic configuration updates are not supported at the moment. */
+  protected[core] val MIN_INSTANCES_LIMIT: Int = 0
+
+  /**
+   * Creates ContainerConcurrencyLimit for limit, iff limit is within permissible range.
+   *
+   * @param maxConcurrenctInstances the limit, must be within permissible range
+   * @return ConcurrencyLimit with limit set
+   * @throws IllegalArgumentException if limit does not conform to requirements
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(maxConcurrenctInstances: Int): InstanceConcurrencyLimit = {
+    require(
+      maxConcurrenctInstances >= MIN_INSTANCES_LIMIT,
+      Messages.belowMinAllowedActionInstanceConcurrency(MIN_INSTANCES_LIMIT))
+    new InstanceConcurrencyLimit(maxConcurrenctInstances)
+  }
+
+  override protected[core] implicit val serdes = new RootJsonFormat[InstanceConcurrencyLimit] {
+    def write(m: InstanceConcurrencyLimit) = JsNumber(m.maxConcurrentInstances)
+
+    def read(value: JsValue) = {
+      Try {
+        val JsNumber(c) = value
+        require(c.isWhole, "instance concurrency limit must be whole number")
+
+        InstanceConcurrencyLimit(c.toInt)
+      } match {
+        case Success(limit)                       => limit
+        case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
+        case Failure(e: Throwable)                => deserializationError("instance concurrency limit malformed", e)
+      }
+    }
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceConcurrencyLimit.scala
@@ -39,7 +39,7 @@ import spray.json._
  *
  * @param maxConcurrentInstances the max number of concurrent activations in a single container
  */
-protected[entity] class InstanceConcurrencyLimit private(val maxConcurrentInstances: Int) extends AnyVal
+protected[entity] class InstanceConcurrencyLimit private (val maxConcurrentInstances: Int) extends AnyVal
 
 protected[core] object InstanceConcurrencyLimit extends ArgNormalizer[InstanceConcurrencyLimit] {
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/IntraConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/IntraConcurrencyLimit.scala
@@ -42,7 +42,7 @@ case class IntraConcurrencyLimitConfig(min: Int, max: Int, std: Int)
  *
  * @param maxConcurrent the max number of concurrent activations in a single container
  */
-protected[entity] class IntraConcurrencyLimit private(val maxConcurrent: Int) extends AnyVal {
+protected[entity] class IntraConcurrencyLimit private (val maxConcurrent: Int) extends AnyVal {
 
   /** It checks the namespace memory limit setting value  */
   @throws[ActionConcurrencyLimitException]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
@@ -46,11 +46,13 @@ protected[entity] abstract class Limits {
  * @param memory the memory limit in megabytes, assured to be non-null because it is a value
  * @param logs the limit for logs written by the container and stored in the activation record, assured to be non-null because it is a value
  * @param concurrency the limit on concurrently processed activations per container, assured to be non-null because it is a value
+ * @param instances the limit in which an action can scale up to within the confines of the namespace's concurrency limit
  */
 protected[core] case class ActionLimits(timeout: TimeLimit = TimeLimit(),
                                         memory: MemoryLimit = MemoryLimit(),
                                         logs: LogLimit = LogLimit(),
-                                        concurrency: ConcurrencyLimit = ConcurrencyLimit())
+                                        concurrency: IntraConcurrencyLimit = IntraConcurrencyLimit(),
+                                        instances: Option[InstanceConcurrencyLimit] = None)
     extends Limits {
   override protected[entity] def toJson = ActionLimits.serdes.write(this)
 
@@ -73,19 +75,19 @@ protected[core] case class TriggerLimits protected[core] () extends Limits {
 protected[core] object ActionLimits extends ArgNormalizer[ActionLimits] with DefaultJsonProtocol {
 
   override protected[core] implicit val serdes = new RootJsonFormat[ActionLimits] {
-    val helper = jsonFormat4(ActionLimits.apply)
+    val helper = jsonFormat5(ActionLimits.apply)
 
     def read(value: JsValue) = {
       val obj = Try {
         value.asJsObject.convertTo[Map[String, JsValue]]
       } getOrElse deserializationError("no valid json object passed")
 
-      val time = TimeLimit.serdes.read(obj.get("timeout") getOrElse deserializationError("'timeout' is missing"))
-      val memory = MemoryLimit.serdes.read(obj.get("memory") getOrElse deserializationError("'memory' is missing"))
-      val logs = obj.get("logs") map { LogLimit.serdes.read(_) } getOrElse LogLimit()
-      val concurrency = obj.get("concurrency") map { ConcurrencyLimit.serdes.read(_) } getOrElse ConcurrencyLimit()
-
-      ActionLimits(time, memory, logs, concurrency)
+      val time = TimeLimit.serdes.read(obj.getOrElse("timeout", deserializationError("'timeout' is missing")))
+      val memory = MemoryLimit.serdes.read(obj.getOrElse("memory", deserializationError("'memory' is missing")))
+      val logs = obj.get("logs") map { LogLimit.serdes.read } getOrElse LogLimit()
+      val concurrency = obj.get("concurrency") map { IntraConcurrencyLimit.serdes.read } getOrElse IntraConcurrencyLimit()
+      val instances = obj.get("instances") map { InstanceConcurrencyLimit.serdes.read }
+      ActionLimits(time, memory, logs, concurrency, instances)
     }
 
     def write(a: ActionLimits) = helper.write(a)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -40,7 +40,8 @@ import org.apache.openwhisk.core.entity.types.EntityStore
 case class ActionLimitsOption(timeout: Option[TimeLimit],
                               memory: Option[MemoryLimit],
                               logs: Option[LogLimit],
-                              concurrency: Option[ConcurrencyLimit])
+                              concurrency: Option[IntraConcurrencyLimit],
+                              instances: Option[InstanceConcurrencyLimit] = None)
 
 /**
  * WhiskActionPut is a restricted WhiskAction view that eschews properties
@@ -647,7 +648,7 @@ object WhiskActionMetaData
 }
 
 object ActionLimitsOption extends DefaultJsonProtocol {
-  implicit val serdes = jsonFormat4(ActionLimitsOption.apply)
+  implicit val serdes = jsonFormat5(ActionLimitsOption.apply)
 }
 
 object WhiskActionPut extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -72,6 +72,12 @@ object Messages {
   def tooManyConcurrentRequests(count: Int, allowed: Int) =
     s"Too many concurrent requests in flight (count: $count, allowed: $allowed)."
 
+  def maxActionInstanceConcurrencyExceedsNamespace(namespaceConcurrencyLimit: Int) =
+    s"Max action instance concurrency must not exceed your namespace concurrency of $namespaceConcurrencyLimit."
+
+  def belowMinAllowedActionInstanceConcurrency(minThreshold: Int) =
+    s"Action container concurrency must be greater than or equal to $minThreshold."
+
   /** System overload message. */
   val systemOverloaded = "System is overloaded, try again later."
 

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1800,8 +1800,13 @@
         "concurrency": {
           "type": "integer",
           "format": "int32",
-          "description": "number of concurrent activations allowed",
+          "description": "number of concurrent activations allowed within an instance",
           "default": 1
+        },
+        "instances": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Max number of instances allowed for an action. Must be less than or equal to namespace concurrency limit. Default is the namespace concurrency limit."
         }
       }
     },
@@ -2873,11 +2878,15 @@
         },
         "minActionConcurrency": {
           "type": "integer",
-          "description": "Min number of concurrent activations allowed"
+          "description": "Min number of concurrent activations within an instance allowed"
         },
         "maxActionConcurrency": {
           "type": "integer",
-          "description": "Max number of concurrent activations allowed"
+          "description": "Max number of concurrent activations within an instance allowed"
+        },
+        "maxActionInstances": {
+          "type": "integer",
+          "description": "Max number of concurrent instances allowed for an action"
         }
       }
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -220,7 +220,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
 
         onComplete(check) {
           case Success(_) =>
-            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, () => {
+            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request), () => {
               make(user, entityName, request)
             })
           case Failure(f) =>
@@ -455,7 +455,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         l.timeout getOrElse TimeLimit(),
         l.memory getOrElse MemoryLimit(),
         l.logs getOrElse LogLimit(),
-        l.concurrency getOrElse ConcurrencyLimit())
+        l.concurrency getOrElse IntraConcurrencyLimit(),
+        l.instances)
     } getOrElse ActionLimits()
     // This is temporary while we are making sequencing directly supported in the controller.
     // The parameter override allows this to work with Pipecode.code. Any parameters other
@@ -503,37 +504,41 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   /** Creates a WhiskAction from PUT content, generating default values where necessary. */
   private def make(user: Identity, entityName: FullyQualifiedEntityName, content: WhiskActionPut)(
     implicit transid: TransactionId) = {
-    content.exec map {
-      case seq: SequenceExec =>
-        // check that the sequence conforms to max length and no recursion rules
-        checkSequenceActionLimits(entityName, seq.components) map { _ =>
-          makeWhiskAction(content.replace(seq), entityName)
-        }
-      case supportedExec if !supportedExec.deprecated =>
-        Future successful makeWhiskAction(content, entityName)
-      case deprecatedExec =>
-        Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
+    checkInstanceConcurrencyLessThanNamespaceConcurrency(user, content) flatMap { _ =>
+      content.exec map {
+        case seq: SequenceExec =>
+          // check that the sequence conforms to max length and no recursion rules
+          checkSequenceActionLimits(entityName, seq.components) map { _ =>
+            makeWhiskAction(content.replace(seq), entityName)
+          }
+        case supportedExec if !supportedExec.deprecated =>
+          Future successful makeWhiskAction(content, entityName)
+        case deprecatedExec =>
+          Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
 
-    } getOrElse Future.failed(RejectRequest(BadRequest, "exec undefined"))
+      } getOrElse Future.failed(RejectRequest(BadRequest, "exec undefined"))
+    }
   }
 
   /** Updates a WhiskAction from PUT content, merging old action where necessary. */
   private def update(user: Identity, content: WhiskActionPut)(action: WhiskAction)(implicit transid: TransactionId) = {
-    content.exec map {
-      case seq: SequenceExec =>
-        // check that the sequence conforms to max length and no recursion rules
-        checkSequenceActionLimits(FullyQualifiedEntityName(action.namespace, action.name), seq.components) map { _ =>
-          updateWhiskAction(content.replace(seq), action)
+    checkInstanceConcurrencyLessThanNamespaceConcurrency(user, content) flatMap { _ =>
+      content.exec map {
+        case seq: SequenceExec =>
+          // check that the sequence conforms to max length and no recursion rules
+          checkSequenceActionLimits(FullyQualifiedEntityName(action.namespace, action.name), seq.components) map { _ =>
+            updateWhiskAction(content.replace(seq), action)
+          }
+        case supportedExec if !supportedExec.deprecated =>
+          Future successful updateWhiskAction(content, action)
+        case deprecatedExec =>
+          Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
+      } getOrElse {
+        if (!action.exec.deprecated) {
+          Future successful updateWhiskAction(content, action)
+        } else {
+          Future failed RejectRequest(BadRequest, runtimeDeprecated(action.exec))
         }
-      case supportedExec if !supportedExec.deprecated =>
-        Future successful updateWhiskAction(content, action)
-      case deprecatedExec =>
-        Future failed RejectRequest(BadRequest, runtimeDeprecated(deprecatedExec))
-    } getOrElse {
-      if (!action.exec.deprecated) {
-        Future successful updateWhiskAction(content, action)
-      } else {
-        Future failed RejectRequest(BadRequest, runtimeDeprecated(action.exec))
       }
     }
   }
@@ -547,7 +552,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         l.timeout getOrElse action.limits.timeout,
         l.memory getOrElse action.limits.memory,
         l.logs getOrElse action.limits.logs,
-        l.concurrency getOrElse action.limits.concurrency)
+        l.concurrency getOrElse action.limits.concurrency,
+        if (l.instances.isDefined) l.instances else action.limits.instances)
     } getOrElse action.limits
 
     // This is temporary while we are making sequencing directly supported in the controller.
@@ -682,6 +688,25 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
       case _: SequenceWithCycle        => Future failed RejectRequest(BadRequest, sequenceIsCyclic)
       case _: NoDocumentException      => Future failed RejectRequest(BadRequest, sequenceComponentNotFound)
     }
+  }
+
+  private def checkInstanceConcurrencyLessThanNamespaceConcurrency(user: Identity, content: WhiskActionPut)(
+    implicit transid: TransactionId): Future[Unit] = {
+    val namespaceConcurrencyLimit =
+      user.limits.concurrentInvocations.getOrElse(whiskConfig.actionInvokeConcurrentLimit.toInt)
+    content.limits
+      .map(
+        l =>
+          l.instances
+            .map(
+              m =>
+                if (m.maxConcurrentInstances > namespaceConcurrencyLimit)
+                  Future failed RejectRequest(
+                    BadRequest,
+                    maxActionInstanceConcurrencyExceedsNamespace(namespaceConcurrencyLimit))
+                else Future.successful({}))
+            .getOrElse(Future.successful({})))
+      .getOrElse(Future.successful({}))
   }
 
   /**

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
@@ -24,7 +24,7 @@ import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.entitlement.{Collection, Privilege, Resource}
 import org.apache.openwhisk.core.entitlement.Privilege.READ
-import org.apache.openwhisk.core.entity.{IntraConcurrencyLimit, Identity, LogLimit, MemoryLimit, TimeLimit}
+import org.apache.openwhisk.core.entity.{Identity, IntraConcurrencyLimit, LogLimit, MemoryLimit, TimeLimit}
 
 trait WhiskLimitsApi extends Directives with AuthenticatedRouteProvider with AuthorizedRouteProvider {
 
@@ -65,8 +65,7 @@ trait WhiskLimitsApi extends Directives with AuthenticatedRouteProvider with Aut
               maxActionConcurrency = Some(IntraConcurrencyLimit(user.limits.allowedMaxActionConcurrency)),
               minActionConcurrency = Some(IntraConcurrencyLimit(user.limits.allowedMinActionConcurrency)),
               maxParameterSize = Some(user.limits.allowedMaxParameterSize),
-              maxActionInstances =
-                Some(user.limits.concurrentInvocations.getOrElse(concurrentInvocationsSystemDefault)))
+              maxActionInstances = Some(user.limits.concurrentInvocations.getOrElse(concurrentInvocationsSystemDefault)))
             pathEndOrSingleSlash { complete(OK, limits) }
           case _ => reject //should never get here
         }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
@@ -24,7 +24,7 @@ import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.entitlement.{Collection, Privilege, Resource}
 import org.apache.openwhisk.core.entitlement.Privilege.READ
-import org.apache.openwhisk.core.entity.{ConcurrencyLimit, Identity, LogLimit, MemoryLimit, TimeLimit}
+import org.apache.openwhisk.core.entity.{IntraConcurrencyLimit, Identity, LogLimit, MemoryLimit, TimeLimit}
 
 trait WhiskLimitsApi extends Directives with AuthenticatedRouteProvider with AuthorizedRouteProvider {
 
@@ -62,9 +62,11 @@ trait WhiskLimitsApi extends Directives with AuthenticatedRouteProvider with Aut
               minActionLogs = Some(LogLimit(user.limits.allowedMinActionLogs)),
               maxActionTimeout = Some(TimeLimit(user.limits.allowedMaxActionTimeout)),
               minActionTimeout = Some(TimeLimit(user.limits.allowedMinActionTimeout)),
-              maxActionConcurrency = Some(ConcurrencyLimit(user.limits.allowedMaxActionConcurrency)),
-              minActionConcurrency = Some(ConcurrencyLimit(user.limits.allowedMinActionConcurrency)),
-              maxParameterSize = Some(user.limits.allowedMaxParameterSize))
+              maxActionConcurrency = Some(IntraConcurrencyLimit(user.limits.allowedMaxActionConcurrency)),
+              minActionConcurrency = Some(IntraConcurrencyLimit(user.limits.allowedMinActionConcurrency)),
+              maxParameterSize = Some(user.limits.allowedMaxParameterSize),
+              maxActionInstances =
+                Some(user.limits.concurrentInvocations.getOrElse(concurrentInvocationsSystemDefault)))
             pathEndOrSingleSlash { complete(OK, limits) }
           case _ => reject //should never get here
         }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -67,7 +67,8 @@ class LeanBalancer(config: WhiskConfig,
   /** Creates an invoker for executing user actions. There is only one invoker in the lean model. */
   private def makeALocalThreadedInvoker(): Unit = {
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
-    val limitConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
+    val limitConfig: IntraConcurrencyLimitConfig =
+      loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
     SpiLoader.get[InvokerProvider].instance(config, invokerName, messageProducer, poolConfig, limitConfig)
   }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -67,7 +67,7 @@ class LeanBalancer(config: WhiskConfig,
   /** Creates an invoker for executing user actions. There is only one invoker in the lean model. */
   private def makeALocalThreadedInvoker(): Unit = {
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
-    val limitConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
+    val limitConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
     SpiLoader.get[InvokerProvider].instance(config, invokerName, messageProducer, poolConfig, limitConfig)
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -611,7 +611,12 @@ class FunctionPullingContainerProxy(
       if (runningActivations.isEmpty) {
         logging.info(this, s"The Client closed in state: $stateName, action: ${data.action}")
         // Stop ContainerProxy(ActivationClientProxy will stop also when send ClientClosed to ContainerProxy).
-        cleanUp(data.container, None, false)
+        cleanUp(
+          data.container,
+          data.invocationNamespace,
+          data.action.fullyQualifiedName(withVersion = true),
+          data.action.rev,
+          None)
       } else {
         logging.info(
           this,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -62,7 +62,7 @@ object FPCInvokerReactive extends InvokerProvider {
     instance: InvokerInstanceId,
     producer: MessageProducer,
     poolConfig: ContainerPoolConfig,
-    limitsConfig: ConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore =
+    limitsConfig: IntraConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore =
     new FPCInvokerReactive(config, instance, producer, poolConfig, limitsConfig)
 }
 
@@ -71,7 +71,7 @@ class FPCInvokerReactive(config: WhiskConfig,
                          producer: MessageProducer,
                          poolConfig: ContainerPoolConfig =
                            loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool),
-                         limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](
+                         limitsConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](
                            ConfigKeys.concurrencyLimit))(implicit actorSystem: ActorSystem, logging: Logging)
     extends InvokerCore {
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -107,7 +107,7 @@ object Invoker {
       ActorSystem(name = "invoker-actor-system", defaultExecutionContext = Some(ec))
     implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
     val poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool)
-    val limitConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
+    val limitConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
     val tags: Seq[String] = Some(loadConfigOrThrow[String](ConfigKeys.invokerResourceTags))
       .map(_.trim())
       .filter(_ != "")
@@ -240,7 +240,7 @@ trait InvokerProvider extends Spi {
                instance: InvokerInstanceId,
                producer: MessageProducer,
                poolConfig: ContainerPoolConfig,
-               limitsConfig: ConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore
+               limitsConfig: IntraConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore
 }
 
 // this trait can be used to add common implementation

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -107,7 +107,8 @@ object Invoker {
       ActorSystem(name = "invoker-actor-system", defaultExecutionContext = Some(ec))
     implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
     val poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool)
-    val limitConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
+    val limitConfig: IntraConcurrencyLimitConfig =
+      loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
     val tags: Seq[String] = Some(loadConfigOrThrow[String](ConfigKeys.invokerResourceTags))
       .map(_.trim())
       .filter(_ != "")
@@ -236,11 +237,12 @@ object Invoker {
  * An Spi for providing invoker implementation.
  */
 trait InvokerProvider extends Spi {
-  def instance(config: WhiskConfig,
-               instance: InvokerInstanceId,
-               producer: MessageProducer,
-               poolConfig: ContainerPoolConfig,
-               limitsConfig: IntraConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore
+  def instance(
+    config: WhiskConfig,
+    instance: InvokerInstanceId,
+    producer: MessageProducer,
+    poolConfig: ContainerPoolConfig,
+    limitsConfig: IntraConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore
 }
 
 // this trait can be used to add common implementation

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -50,7 +50,7 @@ object InvokerReactive extends InvokerProvider {
     instance: InvokerInstanceId,
     producer: MessageProducer,
     poolConfig: ContainerPoolConfig,
-    limitsConfig: ConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore =
+    limitsConfig: IntraConcurrencyLimitConfig)(implicit actorSystem: ActorSystem, logging: Logging): InvokerCore =
     new InvokerReactive(config, instance, producer, poolConfig, limitsConfig)
 }
 
@@ -59,7 +59,7 @@ class InvokerReactive(
   instance: InvokerInstanceId,
   producer: MessageProducer,
   poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool),
-  limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit))(
+  limitsConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit))(
   implicit actorSystem: ActorSystem,
   logging: Logging)
     extends InvokerCore {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -59,9 +59,8 @@ class InvokerReactive(
   instance: InvokerInstanceId,
   producer: MessageProducer,
   poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool),
-  limitsConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](ConfigKeys.concurrencyLimit))(
-  implicit actorSystem: ActorSystem,
-  logging: Logging)
+  limitsConfig: IntraConcurrencyLimitConfig = loadConfigOrThrow[IntraConcurrencyLimitConfig](
+    ConfigKeys.concurrencyLimit))(implicit actorSystem: ActorSystem, logging: Logging)
     extends InvokerCore {
 
   implicit val ec: ExecutionContext = actorSystem.dispatcher

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -45,9 +45,9 @@ dependencies {
 
     testImplementation "junit:junit:4.11"
     testImplementation "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
-    testImplementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
+    testImplementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1"
     constraints {
-        testImplementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0")
+        testImplementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1")
         testImplementation('org.apache.avro:avro:1.11.1') {
             because 'embeddedkafka dependency cannot be upgraded currently and avro in embedded kafka 2.4.0 has vulns'
         }

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KafkaSpecBase.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KafkaSpecBase.scala
@@ -17,8 +17,8 @@
 
 package org.apache.openwhisk.core.monitoring.metrics
 
-import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
-import net.manub.embeddedkafka.EmbeddedKafka
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
+import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 
@@ -30,11 +30,25 @@ abstract class KafkaSpecBase
     with ScalaFutures
     with FlatSpecLike
     with EmbeddedKafka
-    with EmbeddedKafkaLike
     with IntegrationPatience
     with Eventually
     with EventsTestHelper { this: Suite =>
   implicit val timeoutConfig: PatienceConfig = PatienceConfig(1.minute)
   override val sleepAfterProduce: FiniteDuration = 10.seconds
   override protected val topicCreationTimeout = 60.seconds
+  override protected val producerPublishTimeout: FiniteDuration = 60.seconds
+
+  lazy implicit val embeddedKafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
+
+  override def bootstrapServers = s"localhost:${embeddedKafkaConfig.kafkaPort}"
+
+  override def setUp(): Unit = {
+    EmbeddedKafka.start()(embeddedKafkaConfig)
+    super.setUp()
+  }
+
+  override def cleanUp(): Unit = {
+    super.cleanUp()
+    EmbeddedKafka.stop()
+  }
 }

--- a/core/scheduler/build.gradle
+++ b/core/scheduler/build.gradle
@@ -66,6 +66,7 @@ dependencies {
         resolutionStrategy.force "com.typesafe.akka:akka-http-spray-json_${gradle.scala.depVersion}:${gradle.akka_http.version}"
         resolutionStrategy.force "com.typesafe.akka:akka-parsing_${gradle.scala.depVersion}:${gradle.akka_http.version}"
         resolutionStrategy.force "com.typesafe.akka:akka-http_${gradle.scala.depVersion}:${gradle.akka_http.version}"
+        resolutionStrategy.force "com.google.protobuf:protoc:${gradle.protoc.version}"
     }
     implementation "org.scala-lang:scala-library:${gradle.scala.version}"
     implementation project(':common:scala')

--- a/core/scheduler/build.gradle
+++ b/core/scheduler/build.gradle
@@ -66,7 +66,9 @@ dependencies {
         resolutionStrategy.force "com.typesafe.akka:akka-http-spray-json_${gradle.scala.depVersion}:${gradle.akka_http.version}"
         resolutionStrategy.force "com.typesafe.akka:akka-parsing_${gradle.scala.depVersion}:${gradle.akka_http.version}"
         resolutionStrategy.force "com.typesafe.akka:akka-http_${gradle.scala.depVersion}:${gradle.akka_http.version}"
-        resolutionStrategy.force "com.google.protobuf:protoc:${gradle.protoc.version}"
+        resolutionStrategy.dependencySubstitution {
+            substitute module("com.google.protobuf:protoc") using module("com.google.protobuf:protoc:${gradle.protoc.version}") because "previous versions didn't target M1 architecture"
+        }
     }
     implementation "org.scala-lang:scala-library:${gradle.scala.version}"
     implementation project(':common:scala')

--- a/core/scheduler/src/main/resources/application.conf
+++ b/core/scheduler/src/main/resources/application.conf
@@ -53,6 +53,8 @@ akka {
   }
 }
 
+akka-kryo-serialization.kryo-initializer = "org.apache.openwhisk.core.scheduler.CompatibleKryoInitializer"
+
 whisk {
   cluster {
     use-cluster-bootstrap: false

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -26,6 +26,8 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.config.ConfigValueFactory
+import io.altoo.akka.serialization.kryo.DefaultKryoInitializer
+import io.altoo.akka.serialization.kryo.serializer.scala.ScalaKryo
 import kamon.Kamon
 import org.apache.openwhisk.common.Https.HttpsConfig
 import org.apache.openwhisk.common._
@@ -425,3 +427,9 @@ case class SchedulingConfig(staleThreshold: FiniteDuration,
                             dropInterval: FiniteDuration,
                             allowOverProvisionBeforeThrottle: Boolean,
                             namespaceOverProvisionBeforeThrottleRatio: Double)
+
+class CompatibleKryoInitializer extends DefaultKryoInitializer {
+  override def preInit(kryo: ScalaKryo): Unit = {
+    kryo.setDefaultSerializer(classOf[com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer[_]])
+  }
+}

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
@@ -699,12 +699,16 @@ class MemoryQueue(private val etcdClient: EtcdClient,
     cleanUpWatcher()
     cleanUpData()
 
+    context.parent ! queueRemovedMsg
+
     goto(Removed) using NoData()
   }
 
   private def cleanUpActorsAndGotoRemoved(data: FlushingData) = {
     cleanUpActors(data)
     cleanUpData()
+
+    context.parent ! queueRemovedMsg
 
     goto(Removed) using NoData()
   }

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
@@ -1222,6 +1222,11 @@ object MemoryQueue {
           LoggingMarkers
             .SCHEDULER_QUEUE_NOT_PROCESSING(invocationNamespace, action.asString, action.toStringWithoutVersion),
           1)
+      } else {
+        MetricEmitter.emitGaugeMetric(
+          LoggingMarkers
+            .SCHEDULER_QUEUE_NOT_PROCESSING(invocationNamespace, action.asString, action.toStringWithoutVersion),
+          0)
       }
 
       queueRef ! DropOld

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
@@ -1218,17 +1218,10 @@ object MemoryQueue {
         s"[$invocationNamespace:$action:$stateName] some activations are stale msg: ${queue.head.msg.activationId}.")
       val timeSinceLastActivationGrabbed = clock.now().toEpochMilli - lastActivationExecutedTime.get()
       if (timeSinceLastActivationGrabbed > maxRetentionMs && timeSinceLastActivationGrabbed > actionMetaData.limits.timeout.millis) {
-        MetricEmitter.emitGaugeMetric(
+        MetricEmitter.emitCounterMetric(
           LoggingMarkers
-            .SCHEDULER_QUEUE_NOT_PROCESSING(invocationNamespace, action.asString, action.toStringWithoutVersion),
-          1)
-      } else {
-        MetricEmitter.emitGaugeMetric(
-          LoggingMarkers
-            .SCHEDULER_QUEUE_NOT_PROCESSING(invocationNamespace, action.asString, action.toStringWithoutVersion),
-          0)
+            .SCHEDULER_QUEUE_NOT_PROCESSING(invocationNamespace, action.asString, action.toStringWithoutVersion))
       }
-
       queueRef ! DropOld
     }
   }

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -144,8 +144,7 @@ processResources {
     }
 }
 
-// This normalization has been added in order to get a cache hit
-// when running tasks whose consider as inputs the resources
+// Ignores the property `git.build.time` in `git.properties` files to allow `compileScala` task to be cached
 normalization {
     runtimeClasspath {
         properties('**/git.properties') {

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -46,6 +46,7 @@ task downloadSwagger(type: Download) {
 
 
 task copySwagger(type: Copy) {
+    dependsOn(downloadSwagger)
     mkdir("$buildDir/tmp/swagger")
     def destFile = file("$buildDir/tmp/swagger/swagger-ui.tar")
     def uiDir = file("$buildDir/tmp/swagger/swagger-ui")
@@ -56,8 +57,6 @@ task copySwagger(type: Copy) {
     includeEmptyDirs = false
     project.ext.swaggerUiDir = file("$buildDir/tmp/swagger/swagger-ui/swagger-ui-${gradle.swagger.version}/dist")
 }
-
-copySwagger.dependsOn downloadSwagger
 
 def apiGwActions = ['createApi', "deleteApi", "getApi"]
 

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -145,6 +145,16 @@ processResources {
     }
 }
 
+// This normalization has been added in order to get a cache hit
+// when running tasks whose consider as inputs the resources
+normalization {
+    runtimeClasspath {
+        properties('**/git.properties') {
+            ignoreProperty 'git.build.time'
+        }
+    }
+}
+
 task copyBootJarToBin(type:Copy){
     from ("${buildDir}/libs")
     into file("${project.rootProject.projectDir}/bin")

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -169,9 +169,9 @@ dependencies {
     implementation project(':tools:admin')
     implementation "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
 
-    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
+    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1"
     constraints {
-        implementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0")
+        implementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1")
         implementation('org.apache.avro:avro:1.11.1') {
             because 'embeddedkafka dependency cannot be upgraded currently and avro in embedded kafka 2.4.0 has vulns'
         }

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -22,7 +22,8 @@ plugins {
     id 'org.scoverage'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'scala'
-    id 'com.gorylenko.gradle-git-properties' version '2.0.0'
+    id 'com.gorylenko.gradle-git-properties' version '2.4.1'
+    id "de.undercouch.download" version "5.3.1"
 }
 
 ext.dockerImageName = 'standalone'
@@ -37,30 +38,41 @@ scoverage {
     scoverageScalaVersion.set("${gradle.scala.scoverageScalaVersion}")
 }
 
+task downloadSwagger(type: Download) {
+    src "https://github.com/swagger-api/swagger-ui/archive/v${gradle.swagger.version}.tar.gz"
+    dest file("$buildDir/tmp/swagger/swagger-ui.tar")
+    overwrite false
+}
+
+
 task copySwagger(type: Copy) {
-    def version = "3.6.0"
     mkdir("$buildDir/tmp/swagger")
     def destFile = file("$buildDir/tmp/swagger/swagger-ui.tar")
     def uiDir = file("$buildDir/tmp/swagger/swagger-ui")
-    if (!destFile.exists()) {
-        ant.get(src: "https://github.com/swagger-api/swagger-ui/archive/v${version}.tar.gz", dest: destFile)
-    }
     from(tarTree(resources.gzip(destFile))){
-        include("swagger-ui-${version}/dist/**")
+        include("swagger-ui-${gradle.swagger.version}/dist/**")
     }
     into(uiDir)
     includeEmptyDirs = false
-    project.ext.swaggerUiDir = file("$buildDir/tmp/swagger/swagger-ui/swagger-ui-${version}/dist")
+    project.ext.swaggerUiDir = file("$buildDir/tmp/swagger/swagger-ui/swagger-ui-${gradle.swagger.version}/dist")
 }
+
+copySwagger.dependsOn downloadSwagger
 
 def apiGwActions = ['createApi', "deleteApi", "getApi"]
 
-task copyGWActions() {
+task copyGWActions {
+    def routeMgmtDir = new File(project.projectDir, "../routemgmt")
+    def routeBuildDir = mkdir("$buildDir/tmp/routemgmt")
+
+    apiGwActions.each {
+        inputs.dir(new File(routeMgmtDir, it))
+        outputs.dir(new File(routeBuildDir, it + ".zip"))
+    }
+
     doLast {
-        def routeMgmtDir = new File(project.projectDir, "../routemgmt")
-        def commonDir = new File(routeMgmtDir, "common")
-        def routeBuildDir = mkdir("$buildDir/tmp/routemgmt")
         apiGwActions.each { actionName ->
+            def commonDir = new File(routeMgmtDir, "common")
             def zipFileName = actionName + ".zip"
             def actionDir = new File(routeMgmtDir, actionName)
             def zipFile = new File(routeBuildDir, zipFileName)
@@ -88,19 +100,12 @@ task copyGWActions() {
     }
 }
 
-task copyGrafanaConfig() {
-    doLast {
-        def grafanaDir = new File(project(':core:monitoring:user-events').projectDir, "compose/grafana")
-        def grafanaBuildDir = mkdir("$buildDir/tmp/grafana")
-        def zipFileName = "grafana-config.zip"
-        def zipFile = new File(grafanaBuildDir, zipFileName)
-        if (!zipFile.exists()) {
-            ant.zip(destfile:zipFile){
-                fileset(dir:grafanaDir)
-            }
-            logger.info("Created grafana config zip $zipFileName")
-        }
-    }
+task copyGrafanaConfig(type: Zip) {
+    def grafanaBuildDir = mkdir("$buildDir/tmp/grafana")
+    def grafanaDir = new File(project(':core:monitoring:user-events').projectDir, "compose/grafana")
+    from grafanaDir
+    archiveFileName.set("grafana-config.zip")
+    destinationDirectory.set(grafanaBuildDir)
 }
 
 processResources.dependsOn copySwagger

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -144,15 +144,6 @@ processResources {
     }
 }
 
-// Ignores the property `git.build.time` in `git.properties` files to allow `compileScala` task to be cached
-normalization {
-    runtimeClasspath {
-        properties('**/git.properties') {
-            ignoreProperty 'git.build.time'
-        }
-    }
-}
-
 task copyBootJarToBin(type:Copy){
     from ("${buildDir}/libs")
     into file("${project.rootProject.projectDir}/bin")

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -18,10 +18,9 @@
 package org.apache.openwhisk.standalone
 
 import java.io.File
-
 import akka.actor.ActorSystem
 import kafka.server.KafkaConfig
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.commons.io.FileUtils
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
@@ -30,6 +29,7 @@ import org.apache.openwhisk.core.entity.ControllerInstanceId
 import org.apache.openwhisk.core.loadBalancer.{LeanBalancer, LoadBalancer, LoadBalancerProvider}
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.{checkOrAllocatePort, containerName, createRunCmd}
 
+import java.nio.file.FileSystems
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.io.Directory
 import scala.util.Try
@@ -66,8 +66,10 @@ class KafkaLauncher(
       EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = zkPort, customBrokerProperties = brokerProps)
 
     val t = Try {
-      EmbeddedKafka.startZooKeeper(createDir("zookeeper"))
-      EmbeddedKafka.startKafka(createDir("kafka"))
+      createDir("zookeeper")
+      createDir("kafka")
+      EmbeddedKafka.startZooKeeper(FileSystems.getDefault.getPath(workDir.getPath,"zookeeper"))
+      EmbeddedKafka.startKafka(FileSystems.getDefault.getPath(workDir.getPath,"kafka"))
     }
 
     Future

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -68,8 +68,8 @@ class KafkaLauncher(
     val t = Try {
       createDir("zookeeper")
       createDir("kafka")
-      EmbeddedKafka.startZooKeeper(FileSystems.getDefault.getPath(workDir.getPath,"zookeeper"))
-      EmbeddedKafka.startKafka(FileSystems.getDefault.getPath(workDir.getPath,"kafka"))
+      EmbeddedKafka.startZooKeeper(FileSystems.getDefault.getPath(workDir.getPath, "zookeeper"))
+      EmbeddedKafka.startKafka(FileSystems.getDefault.getPath(workDir.getPath, "kafka"))
     }
 
     Future

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -44,7 +44,7 @@ advanced topics.
   * [Deleting actions](#deleting-actions)
 * [Accessing action metadata within the action body](#accessing-action-metadata-within-the-action-body)
 * [Securing your action](security.md)
-* [Concurrency in actions](concurrency.md)
+* [Concurrency in actions](intra-concurrency.md)
 
 ## Languages and Runtimes
 

--- a/docs/intra-concurrency.md
+++ b/docs/intra-concurrency.md
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 -->
-# Concurrency
+# Intra Instance Concurrency
 
-Concurrency in actions can improve container reuse, and may be beneficial in cases where:
+Concurrency within a container instance of an actions can improve container reuse, and may be beneficial in cases where:
 
 * your action can tolerate multiple activations being processed at once
 * you can rely on external log collection (e.g. via docker log drivers or some decoupled collection process like fluentd)
@@ -29,7 +29,7 @@ Concurrent activation processing within the same action container can be enabled
 
 * enable the akka http client at invoker config
   * e.g. CONFIG_whisk_containerPool_akkaClient=true
-* use a kind that supports concurrency (currently only `nodejs:14`, and `nodejs:12`)
+* use a kind that supports concurrency (**currently only the nodejs family / language**)
 * enable concurrency at runtime container env (nodejs container only allows concurrency when started with an env var __OW_ALLOW_CONCURRENT=true)
   * e.g. CONFIG_whisk_containerFactory_containerArgs_extraArgs_env_0="__OW_ALLOW_CONCURRENT=true"
 * disable log collection at invoker

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -72,18 +72,23 @@ OpenWhisk has a few system limits, including how much memory an action can use a
 **Note:** This default limits are for the open source distribution; production deployments like IBM Cloud Functions likely have higher limits.
 As an operator or developer you can change some of the limits using [Ansible inventory variables](../ansible/README.md#changing-limits).
 
+**Note:** On Openwhisk 2.0 with the scheduler service, **concurrent** in the table below really means the max containers
+that can be provisioned at once for a namespace. The api _may_ be able to accept more activations than this number at once
+depending on a number of factors.
+
 The following table lists the default limits for actions.
 
-| limit | description | configurable | unit | default |
-| ----- | ----------- | ------------ | -----| ------- |
-| timeout | a container is not allowed to run longer than N milliseconds | per action |  milliseconds | 60000 |
-| memory | a container is not allowed to allocate more than N MB of memory | per action | MB | 256 |
-| logs | a container is not allowed to write more than N MB to stdout | per action | MB | 10 |
+| limit | description                                                                               | configurable | unit | default |
+| ----- |-------------------------------------------------------------------------------------------| ------------ | -----| ------- |
+| timeout | a container is not allowed to run longer than N milliseconds                              | per action |  milliseconds | 60000 |
+| memory | a container is not allowed to allocate more than N MB of memory                           | per action | MB | 256 |
+| logs | a container is not allowed to write more than N MB to stdout                              | per action | MB | 10 |
+ | instances | an action is not allowed to have more containers than this value (**new scheduler only**) | per action  | number | namespace concurrency limit |
 | concurrent | no more than N activations may be submitted per namespace either executing or queued for execution | per namespace | number | 100 |
-| minuteRate | no more than N activations may be submitted per namespace per minute | per namespace | number | 120 |
-| codeSize | the maximum size of the action code | configurable, limit per action | MB | 48 |
-| parameters | the maximum size of the parameters that can be attached | not configurable, limit per action/package/trigger | MB | 1 |
-| result | the maximum size of the action result | not configurable, limit per action | MB | 1 |
+| minuteRate | no more than N activations may be submitted per namespace per minute                      | per namespace | number | 120 |
+| codeSize | the maximum size of the action code                                                       | configurable, limit per action | MB | 48 |
+| parameters | the maximum size of the parameters that can be attached                                   | not configurable, limit per action/package/trigger | MB | 1 |
+| result | the maximum size of the action result                                                     | not configurable, limit per action | MB | 1 |
 
 ### Per action timeout (ms) (Default: 60s)
 * The timeout limit N is in the range [100ms..300000ms] and is set per action in milliseconds.
@@ -94,6 +99,15 @@ The following table lists the default limits for actions.
 * The memory limit M is in the range from [128MB..512MB] and is set per action in MB.
 * A user can change the limit when creating the action.
 * A container cannot have more memory allocated than the limit.
+
+### Per action max instance concurrency (Default: namespace limit for concurrent invocations) **Only applicable using new scheduler**
+* The max containers that will be created for an action before throttling in the range from [1..concurrentInvocations limit for namespace]
+* By default the max allowed containers / server instances for an action is equal to the namespace limit.
+* A user can change the limit when creating the action.
+* Defining a lower limit than the namespace limit means your max container concurrency will be the action defined limit.
+* If using actionConcurrency > 1 such that your action can handle multiple requests per instance, your true concurrency limit is actionContainerConcurrency * actionConcurrency.
+* The actions within a namespaces containerConcurrency total do not have to add up to the namespace limit though you can configure it that way to guarantee an action will get exactly the action container concurrency.
+* For example with a namespace limit of 30 with 2 actions each with a container limit of 20; if the first action is using 20, there will still be space for 10 for the other.
 
 ### Per action logs (MB) (Default: 10MB)
 * The log limit N is in the range [0MB..10MB] and is set per action.

--- a/settings.gradle
+++ b/settings.gradle
@@ -78,7 +78,7 @@ gradle.ext.scalafmt = [
 ]
 
 gradle.ext.akka = [version : '2.6.12']
-gradle.ext.akka_kafka = [version : '2.0.2']
+gradle.ext.akka_kafka = [version : '2.0.5']
 gradle.ext.akka_http = [version : '10.2.4']
 gradle.ext.akka_management = [version : '1.0.5']
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -93,6 +93,6 @@ gradle.ext.kube_client = [version: '4.10.3']
 
 gradle.ext.netty = [version : '4.1.87.Final']
 
-gradle.ext.protoc = [version : '3.22.0']
+gradle.ext.protoc = [version : '3.18.0']
 
 gradle.ext.swagger = [version : '3.6.0']

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,14 +16,36 @@
  */
 
 plugins {
-    id "com.gradle.enterprise" version "3.10.2"
+    id 'com.gradle.enterprise' version '3.13.2'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
 }
 
+def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+def isJenkins = System.getenv('JENKINS_URL') != null
+def isCI = isGithubActions || isJenkins
+
 gradleEnterprise {
+    server = "https://ge.apache.org"
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        publishAlwaysIf(System.getenv('CI') != null)
+        capture { taskInputFiles = true }
+        uploadInBackground = !isCI
+        publishAlways()
+        publishIfAuthenticated()
+        obfuscation {
+            // This obfuscates the IP addresses of the build machine in the build scan.
+            // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
+    }
+}
+
+buildCache {
+    local {
+        enabled = !isCI
+    }
+
+    remote(gradleEnterprise.buildCache) {
+        enabled = false
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,12 @@ gradleEnterprise {
     }
 }
 
+buildCache {
+    local {
+        enabled = true
+    }
+}
+
 include 'common:scala'
 
 include 'core:controller'

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,12 +27,6 @@ gradleEnterprise {
     }
 }
 
-buildCache {
-    local {
-        enabled = true
-    }
-}
-
 include 'common:scala'
 
 include 'core:controller'

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "com.gradle.enterprise" version "3.10.2"
+    id "com.gradle.enterprise" version "3.12.4"
 }
 
 gradleEnterprise {
@@ -86,3 +86,5 @@ gradle.ext.curator = [version : '4.3.0']
 gradle.ext.kube_client = [version: '4.10.3']
 
 gradle.ext.netty = [version : '4.1.87.Final']
+
+gradle.ext.protoc = [version: '3.22.0']

--- a/settings.gradle
+++ b/settings.gradle
@@ -93,4 +93,6 @@ gradle.ext.kube_client = [version: '4.10.3']
 
 gradle.ext.netty = [version : '4.1.87.Final']
 
-gradle.ext.protoc = [version: '3.22.0']
+gradle.ext.protoc = [version : '3.22.0']
+
+gradle.ext.swagger = [version : '3.6.0']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -239,9 +239,9 @@ dependencies {
             because 'swagger-request-validator-core cannot be upgraded to 2.x where vuln is remediated'
         }
     }
-    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
+    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1"
     constraints {
-        implementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0")
+        implementation("io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1")
         implementation('org.apache.avro:avro:1.11.1') {
             because 'embeddedkafka dependency cannot be upgraded currently and avro in embedded kafka 2.4.0 has vulns'
         }
@@ -255,7 +255,6 @@ dependencies {
     implementation "com.microsoft.azure:azure-cosmos:3.7.6"
     implementation 'org.testcontainers:elasticsearch:1.17.6'
     implementation 'org.testcontainers:mongodb:1.17.1'
-
     implementation project(':common:scala')
     implementation project(':core:controller')
     implementation project(':core:scheduler')

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -100,7 +100,7 @@ class ContainerPoolTests
     EntityPath("actionSpace"),
     EntityName("actionName"),
     exec,
-    limits = ActionLimits(concurrency = ConcurrencyLimit(if (concurrencyEnabled) 3 else 1)))
+    limits = ActionLimits(concurrency = IntraConcurrencyLimit(if (concurrencyEnabled) 3 else 1)))
   val differentAction = action.copy(name = EntityName("actionName2"))
   val largeAction =
     action.copy(
@@ -1103,13 +1103,13 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
 
     val data = warmedData(
       active = maxConcurrent,
-      action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent))))
+      action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent))))
     val pool = Map('warm -> data)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe None
 
     val data2 = warmedData(
       active = maxConcurrent - 1,
-      action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent))))
+      action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent))))
     val pool2 = Map('warm -> data2)
 
     ContainerPool.schedule(data2.action, data2.invocationNamespace, pool2) shouldBe Some('warm, data2)
@@ -1120,7 +1120,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
 
-    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent)))
     val data = warmingData(active = maxConcurrent - 1, action = action)
     val pool = Map('warming -> data)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warming, data)
@@ -1135,7 +1135,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
 
-    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent)))
     val data = warmingColdData(active = maxConcurrent - 1, action = action)
     val data2 = warmedData(active = maxConcurrent - 1, action = action)
     val pool = Map('warming -> data, 'warm -> data2)
@@ -1146,7 +1146,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
 
-    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent)))
     val data = warmingColdData(active = maxConcurrent - 1, action = action)
     val pool = Map('warmingCold -> data)
     ContainerPool.schedule(data.action, data.invocationNamespace, pool) shouldBe Some('warmingCold, data)
@@ -1162,7 +1162,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
 
-    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent)))
     val data = warmingColdData(active = maxConcurrent - 1, action = action)
     val data2 = warmedData(active = maxConcurrent - 1, action = action)
     val pool = Map('warmingCold -> data, 'warm -> data2)
@@ -1173,7 +1173,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency")).exists(_.toBoolean)
     val maxConcurrent = if (concurrencyEnabled) 25 else 1
 
-    val action = createAction(limits = ActionLimits(concurrency = ConcurrencyLimit(maxConcurrent)))
+    val action = createAction(limits = ActionLimits(concurrency = IntraConcurrencyLimit(maxConcurrent)))
     val data = warmingColdData(active = maxConcurrent - 1, action = action)
     val data2 = warmingData(active = maxConcurrent - 1, action = action)
     val pool = Map('warmingCold -> data, 'warming -> data2)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -87,7 +87,7 @@ class ContainerProxyTests
   val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
 
   val concurrencyEnabled = Option(WhiskProperties.getProperty("whisk.action.concurrency", "false")).exists(_.toBoolean)
-  val testConcurrencyLimit = if (concurrencyEnabled) ConcurrencyLimit(2) else ConcurrencyLimit(1)
+  val testConcurrencyLimit = if (concurrencyEnabled) IntraConcurrencyLimit(2) else IntraConcurrencyLimit(1)
   val concurrentAction = ExecutableWhiskAction(
     EntityPath("actionSpace"),
     EntityName("actionName"),

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -961,7 +961,7 @@ class FunctionPullingContainerProxyTests
     }
     client.send(machine, ClientClosed)
 
-    probe.expectMsgAllOf(ContainerRemoved(false), Transition(machine, Running, Removing))
+    probe.expectMsgAllOf(ContainerRemoved(true), Transition(machine, Running, Removing))
 
     awaitAssert {
       factory.calls should have size 1
@@ -1614,7 +1614,7 @@ class FunctionPullingContainerProxyTests
     client.expectMsg(GracefulShutdown)
     client.send(machine, ClientClosed)
 
-    probe.expectMsgAllOf(ContainerRemoved(false), Transition(machine, Running, Removing))
+    probe.expectMsgAllOf(ContainerRemoved(true), Transition(machine, Running, Removing))
 
     awaitAssert {
       factory.calls should have size 1

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -627,7 +627,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(is)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -655,7 +655,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(is)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -683,7 +683,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(is)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -711,7 +711,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(is)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -739,7 +739,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(is)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -767,7 +767,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(is)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -795,7 +795,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(is)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -823,7 +823,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(is)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -851,7 +851,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(is)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -864,12 +864,12 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "reject create when max concurrency is greater than maximum allowed namespace limit" in {
     implicit val tid = transid()
 
-    val allowed = ConcurrencyLimit.MAX_CONCURRENT - 2
-    val is = ConcurrencyLimit.MAX_CONCURRENT - 1
+    val allowed = IntraConcurrencyLimit.MAX_CONCURRENT - 2
+    val is = IntraConcurrencyLimit.MAX_CONCURRENT - 1
 
     val credsWithNamespaceLimits = WhiskAuthHelpers
       .newIdentity()
-      .copy(limits = UserLimits(maxActionConcurrency = Some(ConcurrencyLimit(allowed))))
+      .copy(limits = UserLimits(maxActionConcurrency = Some(IntraConcurrencyLimit(allowed))))
 
     val content = WhiskActionPut(
       Some(jsDefault("_")),
@@ -879,7 +879,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(is)))))
+          Some(IntraConcurrencyLimit(is)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -892,12 +892,12 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "reject create if exceeds the system max concurrency limit and indicate namespace limit in message" in {
     implicit val tid = transid()
 
-    val allowed = ConcurrencyLimit.MAX_CONCURRENT_DEFAULT - 1
-    val is = ConcurrencyLimit.MAX_CONCURRENT + 1
+    val allowed = IntraConcurrencyLimit.MAX_CONCURRENT_DEFAULT - 1
+    val is = IntraConcurrencyLimit.MAX_CONCURRENT + 1
 
     val credsWithNamespaceLimits = WhiskAuthHelpers
       .newIdentity()
-      .copy(limits = UserLimits(maxActionConcurrency = Some(ConcurrencyLimit(allowed))))
+      .copy(limits = UserLimits(maxActionConcurrency = Some(IntraConcurrencyLimit(allowed))))
 
     val content = WhiskActionPut(
       Some(jsDefault("_")),
@@ -907,7 +907,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(is)))))
+          Some(IntraConcurrencyLimit(is)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
@@ -920,12 +920,12 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "reject create when max concurrency is less than minimum allowed namespace limit" in {
     implicit val tid = transid()
 
-    val allowed = ConcurrencyLimit.MIN_CONCURRENT + 2
-    val is = ConcurrencyLimit.MIN_CONCURRENT + 1
+    val allowed = IntraConcurrencyLimit.MIN_CONCURRENT + 2
+    val is = IntraConcurrencyLimit.MIN_CONCURRENT + 1
 
     val credsWithNamespaceLimits = WhiskAuthHelpers
       .newIdentity()
-      .copy(limits = UserLimits(minActionConcurrency = Some(ConcurrencyLimit(allowed))))
+      .copy(limits = UserLimits(minActionConcurrency = Some(IntraConcurrencyLimit(allowed))))
 
     val content = WhiskActionPut(
       Some(jsDefault("_")),
@@ -935,12 +935,38 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(is)))))
+          Some(IntraConcurrencyLimit(is)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)
       responseAs[String] should include {
         Messages.concurrencyBelowAllowedThreshold(is, allowed)
+      }
+    }
+  }
+
+  it should "reject create when max instance concurrency is greater than namespace's concurrency" in {
+    implicit val tid = transid()
+
+    val credsWithNamespaceLimits = WhiskAuthHelpers
+      .newIdentity()
+      .copy(limits = UserLimits(concurrentInvocations = Some(30)))
+
+    val content = WhiskActionPut(
+      Some(jsDefault("_")),
+      Some(Parameters("x", "X")),
+      Some(
+        ActionLimitsOption(
+          None,
+          None,
+          None,
+          None,
+          Some(InstanceConcurrencyLimit(40)))))
+
+    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
+      status should be(BadRequest)
+      responseAs[String] should include {
+        Messages.maxActionInstanceConcurrencyExceedsNamespace(30)
       }
     }
   }
@@ -1751,7 +1777,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(IntraConcurrencyLimit(IntraConcurrencyLimit.MAX_CONCURRENT)))))
     put(entityStore, action)
     Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       deleteAction(action.docid)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -955,13 +955,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val content = WhiskActionPut(
       Some(jsDefault("_")),
       Some(Parameters("x", "X")),
-      Some(
-        ActionLimitsOption(
-          None,
-          None,
-          None,
-          None,
-          Some(InstanceConcurrencyLimit(40)))))
+      Some(ActionLimitsOption(None, None, None, None, Some(InstanceConcurrencyLimit(40)))))
 
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(credsWithNamespaceLimits)) ~> check {
       status should be(BadRequest)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
@@ -23,7 +23,14 @@ import akka.http.scaladsl.model.StatusCodes.{BadRequest, MethodNotAllowed, OK}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonUnmarshaller
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.core.controller.WhiskLimitsApi
-import org.apache.openwhisk.core.entity.{IntraConcurrencyLimit, EntityPath, LogLimit, MemoryLimit, TimeLimit, UserLimits}
+import org.apache.openwhisk.core.entity.{
+  EntityPath,
+  IntraConcurrencyLimit,
+  LogLimit,
+  MemoryLimit,
+  TimeLimit,
+  UserLimits
+}
 import org.apache.openwhisk.core.entity.size._
 
 import scala.concurrent.duration._

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
@@ -23,7 +23,7 @@ import akka.http.scaladsl.model.StatusCodes.{BadRequest, MethodNotAllowed, OK}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonUnmarshaller
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.core.controller.WhiskLimitsApi
-import org.apache.openwhisk.core.entity.{ConcurrencyLimit, EntityPath, LogLimit, MemoryLimit, TimeLimit, UserLimits}
+import org.apache.openwhisk.core.entity.{IntraConcurrencyLimit, EntityPath, LogLimit, MemoryLimit, TimeLimit, UserLimits}
 import org.apache.openwhisk.core.entity.size._
 
 import scala.concurrent.duration._
@@ -58,8 +58,8 @@ class LimitsApiTests extends ControllerTestCommon with WhiskLimitsApi {
   val testLogMax = LogLimit(6.MB)
   val testDurationMax = TimeLimit(20.seconds)
   val testDurationMin = TimeLimit(10.seconds)
-  val testConcurrencyMax = ConcurrencyLimit(20)
-  val testConcurrencyMin = ConcurrencyLimit(10)
+  val testConcurrencyMax = IntraConcurrencyLimit(20)
+  val testConcurrencyMin = IntraConcurrencyLimit(10)
 
   val creds = WhiskAuthHelpers.newIdentity()
   val credsWithSetLimits = WhiskAuthHelpers
@@ -91,6 +91,8 @@ class LimitsApiTests extends ControllerTestCommon with WhiskLimitsApi {
         responseAs[UserLimits].invocationsPerMinute shouldBe Some(whiskConfig.actionInvokePerMinuteLimit.toInt)
         responseAs[UserLimits].concurrentInvocations shouldBe Some(whiskConfig.actionInvokeConcurrentLimit.toInt)
         responseAs[UserLimits].firesPerMinute shouldBe Some(whiskConfig.triggerFirePerMinuteLimit.toInt)
+        responseAs[UserLimits].maxActionInstances shouldBe Some(whiskConfig.actionInvokeConcurrentLimit.toInt)
+
         responseAs[UserLimits].allowedKinds shouldBe None
         responseAs[UserLimits].storeActivations shouldBe None
 
@@ -101,8 +103,8 @@ class LimitsApiTests extends ControllerTestCommon with WhiskLimitsApi {
         responseAs[UserLimits].maxActionLogs.get.megabytes shouldBe LogLimit.MAX_LOGSIZE_DEFAULT.toMB
         responseAs[UserLimits].minActionTimeout.get.duration shouldBe TimeLimit.MIN_DURATION_DEFAULT
         responseAs[UserLimits].maxActionTimeout.get.duration shouldBe TimeLimit.MAX_DURATION_DEFAULT
-        responseAs[UserLimits].minActionConcurrency.get.maxConcurrent shouldBe ConcurrencyLimit.MIN_CONCURRENT_DEFAULT
-        responseAs[UserLimits].maxActionConcurrency.get.maxConcurrent shouldBe ConcurrencyLimit.MAX_CONCURRENT_DEFAULT
+        responseAs[UserLimits].minActionConcurrency.get.maxConcurrent shouldBe IntraConcurrencyLimit.MIN_CONCURRENT_DEFAULT
+        responseAs[UserLimits].maxActionConcurrency.get.maxConcurrent shouldBe IntraConcurrencyLimit.MAX_CONCURRENT_DEFAULT
       }
     }
   }
@@ -117,6 +119,7 @@ class LimitsApiTests extends ControllerTestCommon with WhiskLimitsApi {
         responseAs[UserLimits].firesPerMinute shouldBe Some(testFiresPerMinute)
         responseAs[UserLimits].allowedKinds shouldBe Some(testAllowedKinds)
         responseAs[UserLimits].storeActivations shouldBe Some(testStoreActivations)
+        responseAs[UserLimits].maxActionInstances shouldBe Some(testConcurrent)
 
         // provide action limits for namespace
         responseAs[UserLimits].minActionMemory.get.megabytes shouldBe testMemoryMin.megabytes

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
@@ -27,7 +27,15 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.openwhisk.common.{AkkaLogging, TransactionId}
 import org.apache.openwhisk.core.database.{CacheInvalidationMessage, RemoteCacheInvalidation}
 import org.apache.openwhisk.core.database.cosmosdb.{CosmosDBArtifactStoreProvider, CosmosDBTestSupport}
-import org.apache.openwhisk.core.entity.{DocumentReader, EntityName, EntityPath, WhiskDocumentReader, WhiskEntity, WhiskEntityJsonFormat, WhiskPackage}
+import org.apache.openwhisk.core.entity.{
+  DocumentReader,
+  EntityName,
+  EntityPath,
+  WhiskDocumentReader,
+  WhiskEntity,
+  WhiskEntityJsonFormat,
+  WhiskPackage
+}
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
@@ -124,5 +124,5 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   }
 
   protected def actionLimits(memory: ByteSize, concurrency: Int): ActionLimits =
-    ActionLimits(memory = MemoryLimit(memory), concurrency = ConcurrencyLimit(concurrency))
+    ActionLimits(memory = MemoryLimit(memory), concurrency = IntraConcurrencyLimit(concurrency))
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -776,12 +776,12 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
         "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
         "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson,
-        "concurrency" -> ConcurrencyLimit.STD_CONCURRENT.toInt.toJson),
+        "concurrency" -> IntraConcurrencyLimit.STD_CONCURRENT.toInt.toJson),
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
         "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
         "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson,
-        "concurrency" -> ConcurrencyLimit.STD_CONCURRENT.toInt.toJson,
+        "concurrency" -> IntraConcurrencyLimit.STD_CONCURRENT.toInt.toJson,
         "foo" -> "bar".toJson),
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -43,7 +43,7 @@ import org.apache.openwhisk.core.entity.{
   ActivationEntityLimit,
   ActivationResponse,
   ByteSize,
-  ConcurrencyLimit,
+  IntraConcurrencyLimit,
   Exec,
   LogLimit,
   MemoryLimit,
@@ -126,11 +126,11 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
     }
     val toConcurrencyString = concurrency match {
       case None                                             => "None"
-      case Some(ConcurrencyLimit.MIN_CONCURRENT)            => s"${ConcurrencyLimit.MIN_CONCURRENT} (= min)"
-      case Some(ConcurrencyLimit.STD_CONCURRENT)            => s"${ConcurrencyLimit.STD_CONCURRENT} (= std)"
-      case Some(ConcurrencyLimit.MAX_CONCURRENT)            => s"${ConcurrencyLimit.MAX_CONCURRENT} (= max)"
-      case Some(c) if (c < ConcurrencyLimit.MIN_CONCURRENT) => s"${c} (< min)"
-      case Some(c) if (c > ConcurrencyLimit.MAX_CONCURRENT) => s"${c} (> max)"
+      case Some(IntraConcurrencyLimit.MIN_CONCURRENT)            => s"${IntraConcurrencyLimit.MIN_CONCURRENT} (= min)"
+      case Some(IntraConcurrencyLimit.STD_CONCURRENT)            => s"${IntraConcurrencyLimit.STD_CONCURRENT} (= std)"
+      case Some(IntraConcurrencyLimit.MAX_CONCURRENT)            => s"${IntraConcurrencyLimit.MAX_CONCURRENT} (= max)"
+      case Some(c) if (c < IntraConcurrencyLimit.MIN_CONCURRENT) => s"${c} (< min)"
+      case Some(c) if (c > IntraConcurrencyLimit.MAX_CONCURRENT) => s"${c} (> max)"
       case Some(c)                                          => s"${c} (allowed)"
     }
     val toExpectedResultString: String = if (ec == SUCCESS_EXIT) "allow" else "reject"
@@ -143,10 +143,10 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       time <- Seq(None, Some(TimeLimit.MIN_DURATION), Some(TimeLimit.MAX_DURATION))
       mem <- Seq(None, Some(MemoryLimit.MIN_MEMORY), Some(MemoryLimit.MAX_MEMORY))
       log <- Seq(None, Some(LogLimit.MIN_LOGSIZE), Some(LogLimit.MAX_LOGSIZE))
-      concurrency <- if (!concurrencyEnabled || (ConcurrencyLimit.MIN_CONCURRENT == ConcurrencyLimit.MAX_CONCURRENT)) {
-        Seq(None, Some(ConcurrencyLimit.MIN_CONCURRENT))
+      concurrency <- if (!concurrencyEnabled || (IntraConcurrencyLimit.MIN_CONCURRENT == IntraConcurrencyLimit.MAX_CONCURRENT)) {
+        Seq(None, Some(IntraConcurrencyLimit.MIN_CONCURRENT))
       } else {
-        Seq(None, Some(ConcurrencyLimit.MIN_CONCURRENT), Some(ConcurrencyLimit.MAX_CONCURRENT))
+        Seq(None, Some(IntraConcurrencyLimit.MIN_CONCURRENT), Some(IntraConcurrencyLimit.MAX_CONCURRENT))
       }
     } yield PermutationTestParameter(time, mem, log, concurrency)
   } ++
@@ -181,7 +181,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
         "timeout" -> parm.timeout.getOrElse(TimeLimit.STD_DURATION).toMillis.toJson,
         "memory" -> parm.memory.getOrElse(MemoryLimit.STD_MEMORY).toMB.toInt.toJson,
         "logs" -> parm.logs.getOrElse(LogLimit.STD_LOGSIZE).toMB.toInt.toJson,
-        "concurrency" -> parm.concurrency.getOrElse(ConcurrencyLimit.STD_CONCURRENT).toJson)
+        "concurrency" -> parm.concurrency.getOrElse(IntraConcurrencyLimit.STD_CONCURRENT).toJson)
 
       val name = "ActionLimitTests-" + Instant.now.toEpochMilli
       val createResult = assetHelper.withCleaner(wsk.action, name, confirmDelete = (parm.ec == SUCCESS_EXIT)) {

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -43,8 +43,8 @@ import org.apache.openwhisk.core.entity.{
   ActivationEntityLimit,
   ActivationResponse,
   ByteSize,
-  IntraConcurrencyLimit,
   Exec,
+  IntraConcurrencyLimit,
   LogLimit,
   MemoryLimit,
   TimeLimit
@@ -125,13 +125,13 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       case Some(l)                               => s"${l} (allowed)"
     }
     val toConcurrencyString = concurrency match {
-      case None                                             => "None"
+      case None                                                  => "None"
       case Some(IntraConcurrencyLimit.MIN_CONCURRENT)            => s"${IntraConcurrencyLimit.MIN_CONCURRENT} (= min)"
       case Some(IntraConcurrencyLimit.STD_CONCURRENT)            => s"${IntraConcurrencyLimit.STD_CONCURRENT} (= std)"
       case Some(IntraConcurrencyLimit.MAX_CONCURRENT)            => s"${IntraConcurrencyLimit.MAX_CONCURRENT} (= max)"
       case Some(c) if (c < IntraConcurrencyLimit.MIN_CONCURRENT) => s"${c} (< min)"
       case Some(c) if (c > IntraConcurrencyLimit.MAX_CONCURRENT) => s"${c} (> max)"
-      case Some(c)                                          => s"${c} (allowed)"
+      case Some(c)                                               => s"${c} (allowed)"
     }
     val toExpectedResultString: String = if (ec == SUCCESS_EXIT) "allow" else "reject"
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueFlowTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueFlowTests.scala
@@ -313,7 +313,7 @@ class MemoryQueueFlowTests
     // this is the case where there is no capacity in a namespace and no container can be created.
     decisionMaker.setAutoPilot((sender: ActorRef, msg) => {
       msg match {
-        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, Running, _) =>
+        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, _, Running, _) =>
           sender ! DecisionResults(EnableNamespaceThrottling(true), 0)
           TestActor.KeepRunning
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
@@ -654,13 +654,14 @@ class MemoryQueueTests
     fsm ! StateTimeout
     expectMsg(Transition(fsm, Idle, Removed))
     queueRef.queue.length shouldBe 0
+    parent.expectMsg(queueRemovedMsg)
+
     fsm ! message
 
     // queue is timed out again in the Removed state.
     parent.expectMsg(message)
 
     fsm ! StateTimeout
-    parent.expectMsg(queueRemovedMsg)
 
     expectNoMessage()
 
@@ -1103,10 +1104,7 @@ class MemoryQueueTests
     fsm ! message
     probe.expectMsg(ActivationResponse.developerError("nonExecutbleAction error"))
 
-    parent.expectMsgAnyOf(
-      2 * queueConfig.flushGrace + 5.seconds,
-      QueueRemoved(testInvocationNamespace, fqn.toDocId.asDocInfo(action.rev), Some(leaderKey)),
-      Transition(fsm, Flushing, Removed))
+    parent.expectMsgAllOf(2 * queueConfig.flushGrace + 5.seconds, queueRemovedMsg, Transition(fsm, Flushing, Removed))
 
     fsm ! StateTimeout
     parent.expectMsg(queueRemovedMsg)
@@ -1409,10 +1407,7 @@ class MemoryQueueTests
 
     val duration = FiniteDuration(queueConfig.maxBlackboxRetentionMs, MILLISECONDS) + queueConfig.flushGrace
     probe.expectMsg(duration, ActivationResponse.whiskError("no available invokers"))
-    parent.expectMsgAnyOf(
-      duration,
-      QueueRemoved(testInvocationNamespace, fqn.toDocId.asDocInfo(action.rev), Some(leaderKey)),
-      Transition(fsm, Flushing, Removed))
+    parent.expectMsgAllOf(duration, queueRemovedMsg, Transition(fsm, Flushing, Removed))
     fsm ! QueueRemovedCompleted
     parent.expectTerminated(fsm)
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
@@ -1529,7 +1529,7 @@ class MemoryQueueTests
     // This test pilot mimic the decision maker who disable the namespace throttling when there is enough capacity.
     decisionMaker.setAutoPilot((sender: ActorRef, msg) => {
       msg match {
-        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, NamespaceThrottled, _) =>
+        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, _, NamespaceThrottled, _) =>
           sender ! DisableNamespaceThrottling
 
         case _ =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/SchedulingDecisionMakerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/SchedulingDecisionMakerTests.scala
@@ -63,7 +63,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 0,
       inProgressContainerCountInNamespace = 0,
       averageDuration = None,
-      limit = 0, // limit is 0,
+      namespaceLimit = 0,
+      actionLimit = 0, // limit is 0,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -87,7 +88,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 0,
       inProgressContainerCountInNamespace = 0,
       averageDuration = None,
-      limit = 0, // limit is 0
+      namespaceLimit = 0,
+      actionLimit = 0, // limit is 0
       maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
@@ -115,7 +117,8 @@ class SchedulingDecisionMakerTests
         existingContainerCountInNamespace = 1,
         inProgressContainerCountInNamespace = 2,
         averageDuration = None, // No average duration available
-        limit = 10,
+        namespaceLimit = 10,
+        actionLimit = 10,
         maxActionConcurrency = 1,
         stateName = state,
         recipient = testProbe.ref)
@@ -142,7 +145,8 @@ class SchedulingDecisionMakerTests
         existingContainerCountInNamespace = 5,
         inProgressContainerCountInNamespace = 8,
         averageDuration = Some(1.0), // Some average duration available
-        limit = 20,
+        namespaceLimit = 20,
+        actionLimit = 20,
         maxActionConcurrency = 1,
         stateName = state,
         recipient = testProbe.ref)
@@ -167,7 +171,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 2,
+      namespaceLimit = 2,
+      actionLimit = 2,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -192,7 +197,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 2, // this value includes the count of this action as well.
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -220,7 +226,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 2,
+      namespaceLimit = 2,
+      actionLimit = 2,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -248,7 +255,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 2,
+      namespaceLimit = 2,
+      actionLimit = 2,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -276,7 +284,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 2,
+      namespaceLimit = 2,
+      actionLimit = 2,
       maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
@@ -304,7 +313,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 2,
+      namespaceLimit = 2,
+      actionLimit = 2,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -332,7 +342,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2, // but there are already 2 containers in this namespace
       inProgressContainerCountInNamespace = 2, // this value includes the count of this action as well.
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -357,7 +368,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -381,7 +393,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
@@ -405,7 +418,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
@@ -430,7 +444,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -455,7 +470,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -480,7 +496,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
@@ -504,7 +521,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
@@ -528,7 +546,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -552,7 +571,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -576,7 +596,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -600,7 +621,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 6,
       averageDuration = None,
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -624,7 +646,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -650,7 +673,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -676,7 +700,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -704,7 +729,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -731,7 +757,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -759,7 +786,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 5,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -786,7 +814,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 0,
       inProgressContainerCountInNamespace = 0,
       averageDuration = None, // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -810,7 +839,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 1,
       averageDuration = Some(1000), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
@@ -837,7 +867,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 2,
       averageDuration = None, // the average duration does not exist
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
@@ -864,7 +895,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -889,7 +921,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50), // the average duration gives container throughput of 2
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
@@ -914,7 +947,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 1,
       inProgressContainerCountInNamespace = 2,
       averageDuration = None, // the average duration does not exist
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
@@ -943,7 +977,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(100.0),
-      limit = 4,
+      namespaceLimit = 4,
+      actionLimit = 4,
       maxActionConcurrency = 2,
       stateName = Running,
       recipient = testProbe.ref)
@@ -970,7 +1005,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50.0),
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 3,
       stateName = Running,
       recipient = testProbe.ref)
@@ -997,7 +1033,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50.0),
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 3,
       stateName = Running,
       recipient = testProbe.ref)
@@ -1025,7 +1062,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 2,
       inProgressContainerCountInNamespace = 0,
       averageDuration = None,
-      limit = 10,
+      namespaceLimit = 10,
+      actionLimit = 10,
       maxActionConcurrency = 3,
       stateName = Running,
       recipient = testProbe.ref)
@@ -1035,5 +1073,61 @@ class SchedulingDecisionMakerTests
     // stale messages are 10. want stale to be handled by first pass of requests from containers so
     // 10 / 3 = 4.0
     testProbe.expectMsg(DecisionResults(AddContainer, 4))
+  }
+
+  it should "add only up to the action container limit if less than the namespace limit" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 100,
+      existingContainerCount = 1,
+      inProgressContainerCount = 0,
+      staleActivationNum = 0,
+      existingContainerCountInNamespace = 2,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = Some(100.0),
+      namespaceLimit = 10,
+      actionLimit = 5,
+      maxActionConcurrency = 3,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // one container already exists with an action limit of 5. Number of messages will exceed limit of containers
+    // so use smaller of the two limits
+    testProbe.expectMsg(DecisionResults(AddContainer, 4))
+  }
+
+  it should "add only up to the namespace limit total if existing containers in namespace prevents reaching action limit" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 100,
+      existingContainerCount = 1,
+      inProgressContainerCount = 0,
+      staleActivationNum = 0,
+      existingContainerCountInNamespace = 7,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = Some(100.0),
+      namespaceLimit = 10,
+      actionLimit = 5,
+      maxActionConcurrency = 3,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // one container already exists with an action limit of 5. There are currently 7 containers in namespace
+    // so can only add 3 more even if that only gives this action 4 containers when it has an action limit of 5
+    testProbe.expectMsg(DecisionResults(EnableNamespaceThrottling(false), 3))
   }
 }

--- a/tools/dev/build.gradle
+++ b/tools/dev/build.gradle
@@ -26,7 +26,7 @@ repositories {
 def owHome = project.projectDir.parentFile.parentFile
 
 dependencies {
-    implementation "org.codehaus.groovy:groovy-all:3.0.14"
+    implementation "org.codehaus.groovy:groovy-all:3.0.17"
     implementation "commons-io:commons-io:2.11.0"
     implementation "org.apache.commons:commons-lang3:3.8.1"
 }

--- a/tools/github/setup.sh
+++ b/tools/github/setup.sh
@@ -20,6 +20,8 @@
 #then echo skipping setup ; exit 0
 #fi
 
+set -e
+
 # retries a command for five times and exits with the non-zero exit if even after
 # the retries the command did not succeed.
 function retry() {


### PR DESCRIPTION
This PR provide little improvements to the Gradle build. 

## Description
Here's a brief list of what changed:
- Add com.google.protobuf:protoc dependency for configurations
- Update version of Gradle Enterprise plugin to version 3.12.4
- Enable local build caching
- Use mavenCentral instead of jcenter as repository
- Use archiveFileName instead of deprecated archiveName property
- Extract swagger download from copySwagger task Explicitly define inputs and outputs for copyGWActions task
- Add normalization to ignore property git.build.time in git.properties files in order to cache some task execution


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

